### PR TITLE
📝 Simplify frontend documentation

### DIFF
--- a/web_app/src/front/checkout.rs
+++ b/web_app/src/front/checkout.rs
@@ -1,5 +1,3 @@
-//! Handlers related to the PetInfo id tag payment
-
 use crate::{
     api, config, consts,
     front::{AppState, errors, forms, middleware, session, templates, utils},
@@ -10,9 +8,7 @@ use ntex::web;
 use ntex_identity::Identity;
 use serde_json::json;
 
-/// Endpoint to render the checkout to pay the PetInfo id tag.
-/// If the user payed without finish the id tag register, the user
-/// will be redirect to the add form
+/// Render checkout page
 #[web::get("")]
 async fn get_checkout_view(
     user_session: session::WebAppSession,
@@ -47,14 +43,12 @@ async fn get_checkout_view(
         .body(content))
 }
 
-/// Represents the process_payment response endpoint [post]
 #[derive(serde::Serialize)]
 struct PaymResponse {
     id: usize,
 }
 
-/// Endpoint to handle the payment request made by the user to adquire a
-/// PetInfo id tag.
+/// Process payment request
 #[web::post("/process_payment")]
 async fn process_payment(
     _: middleware::csrf_token::CsrfToken,

--- a/web_app/src/front/middleware/logged_user.rs
+++ b/web_app/src/front/middleware/logged_user.rs
@@ -1,6 +1,3 @@
-//! Module to serialize the logged user information to:
-//! - Apply business allow actions
-
 use ntex::{
     http::Payload,
     web::{Error, FromRequest, HttpRequest},
@@ -9,8 +6,7 @@ use ntex_identity::RequestIdentity;
 
 use crate::front;
 
-/// Every logged request must have the serialized user [session](crate::front::session::WebAppSession)
-/// this block will extract the logged user session data from the [request](ntex::web::HttpRequest)
+/// Extract logged user session from request
 impl<Err> FromRequest<Err> for front::session::WebAppSession {
     type Error = Error;
 
@@ -23,11 +19,10 @@ impl<Err> FromRequest<Err> for front::session::WebAppSession {
     }
 }
 
-/// Checks if the request is made by a user with a valid membership
+/// Check user has valid service membership
 pub struct CheckUserCanAccessService;
 
-/// Checks if the request is made by a user with
-/// valid conditions to edit its own data
+/// Check user is logged and can edit
 pub struct IsUserLoggedAndCanEdit(pub bool, pub Option<i64>);
 
 impl<Err> FromRequest<Err> for IsUserLoggedAndCanEdit {
@@ -66,7 +61,7 @@ fn serialize_logged_user_session(str: &str) -> serde_json::Result<front::session
     serde_json::from_str::<front::session::WebAppSession>(str)
 }
 
-/// Extracts the [front::session::WebAppSession] from a string session cookie
+/// Extract session from auth cookie
 fn get_logged_user_session(
     auth_cookie: Option<String>,
 ) -> Result<front::session::WebAppSession, Error> {

--- a/web_app/src/front/pet_health.rs
+++ b/web_app/src/front/pet_health.rs
@@ -1,5 +1,3 @@
-//! Handlers related to the /pet/health url
-
 use crate::{
     api,
     front::{
@@ -56,7 +54,7 @@ async fn get_pet_health_view(
         .body(content))
 }
 
-/// Renders pet health records
+/// Render pet health records table
 #[web::get("{pet_external_id}/{record_type}/tbody")]
 async fn pet_health_records(
     IsUserLoggedAndCanEdit(can_edit, user_id): IsUserLoggedAndCanEdit,
@@ -95,8 +93,7 @@ async fn pet_health_records(
         .body(content))
 }
 
-/// Handles the request to add a new health record to a pet by
-/// its external id
+/// Add health record to pet
 #[web::post("{pet_external_id}/{record_type}/add")]
 async fn add_health_record(
     _: middleware::logged_user::CheckUserCanAccessService,
@@ -145,7 +142,7 @@ struct HealthDeletePath {
     record_type: models::pet::PetHealthType,
 }
 
-/// Handles the request to delete a health record to a pet
+/// Delete health record from pet
 #[web::delete("{pet_external_id}/{record_type}/{record_id}")]
 async fn delete_health_record(
     _: middleware::logged_user::CheckUserCanAccessService,

--- a/web_app/src/front/pet_public.rs
+++ b/web_app/src/front/pet_public.rs
@@ -1,5 +1,3 @@
-//! Handlers related to the /info/profile/{external-id} url
-
 use ntex::web;
 use serde_json::json;
 use uuid::Uuid;
@@ -9,9 +7,7 @@ use crate::{
     front::{AppState, errors, oauth, templates},
 };
 
-/// Renders a pet public info based on its `external_id`
-/// If the pet_external_id is not linked to a pet; steps to link the
-/// external id will be shown
+/// Render pet public profile page
 #[web::get("/{pet_external_id}")]
 async fn get_pet_info_view(
     app_state: web::types::State<AppState>,

--- a/web_app/src/front/routes.rs
+++ b/web_app/src/front/routes.rs
@@ -1,53 +1,13 @@
-//! Frontend route configuration module.
-//!
-//! This module organizes and configures all the web routes for the pet info application.
-//! Routes are grouped by functionality into logical scopes for better organization
-//! and maintainability.
-
 use super::{blog, checkout, pet, pet_health, pet_note, pet_public, profile, reminder};
 use crate::webhook;
 use ntex::web;
 
-/// Configures public pet profile routes.
-///
-/// This function sets up routes for viewing pet information without authentication.
-/// These routes are typically used for public pet profiles that can be accessed
-/// via QR codes or direct links.
-///
-/// # Routes
-/// - `GET /info/{pet_external_id}` - View public pet information
+/// Public pet profile routes
 pub fn pet_public_profile(cfg: &mut web::ServiceConfig) {
     cfg.service(web::scope("/info").service((pet_public::get_pet_info_view,)));
 }
 
-/// Configures pet management routes.
-///
-/// This function sets up all routes related to pet CRUD operations, including
-/// pet details, health records, notes, and file downloads. All routes require
-/// user authentication and proper authorization.
-///
-/// # Main Routes
-/// - `GET /pet` - Pet management dashboard
-/// - `GET /pet/list` - List user's pets
-/// - `GET /pet/details/{pet_id}` - Pet details form
-/// - `POST /pet/create` - Create new pet
-/// - `PUT /pet/edit/{pet_id}` - Update pet details
-/// - `DELETE /pet/delete/{pet_id}` - Delete pet
-/// - `GET /pet/qr_code/{pet_external_id}` - Generate QR code
-/// - `GET /pet/pdf_report/{pet_id}` - Generate PDF report
-/// - `GET /pet/public_pic/{pet_external_id}` - Get pet picture
-/// - `GET /pet/pass/{pet_external_id}` - Download Apple Wallet pass
-///
-/// # Health Sub-routes (/pet/health)
-/// - `GET /pet/health/{pet_external_id}/{health_type}` - Health records view
-/// - `POST /pet/health/add` - Add health record
-/// - `DELETE /pet/health/delete` - Delete health record
-///
-/// # Notes Sub-routes (/pet/note)
-/// - `GET /pet/note/{pet_id}` - Pet notes view
-/// - `POST /pet/note/new` - Create new note
-/// - `GET /pet/note/list/{pet_id}` - Get pet notes
-/// - `DELETE /pet/note/delete` - Delete note
+/// Pet CRUD, health records, notes, and file operations
 pub fn pet(cfg: &mut web::ServiceConfig) {
     cfg.service(web::scope("/pet").service((
         pet::get_pet_view,
@@ -77,21 +37,7 @@ pub fn pet(cfg: &mut web::ServiceConfig) {
     )));
 }
 
-/// Configures reminder management routes.
-///
-/// This function sets up routes for managing pet care reminders, including
-/// phone number verification for SMS notifications. All routes require
-/// user authentication.
-///
-/// # Routes
-/// - `GET /reminder` - Reminders management view
-/// - `GET /reminder/list` - Get user's reminders
-/// - `POST /reminder/create` - Create new reminder
-/// - `DELETE /reminder/delete/{reminder_id}` - Delete reminder
-/// - `POST /reminder/phone/start-verification` - Start phone verification
-/// - `POST /reminder/phone/send-code` - Send verification code
-/// - `POST /reminder/phone/verify` - Verify phone number
-/// - `DELETE /reminder/phone/remove` - Remove verified phone
+/// Reminder management and phone verification
 pub fn reminders(cfg: &mut web::ServiceConfig) {
     cfg.service(web::scope("/reminder").service((
         reminder::get_reminder_view,
@@ -105,18 +51,7 @@ pub fn reminders(cfg: &mut web::ServiceConfig) {
     )));
 }
 
-/// Configures user profile management routes.
-///
-/// This function sets up routes for managing user account settings, contact
-/// information, and account operations. All routes require user authentication.
-///
-/// # Routes
-/// - `GET /profile` - User profile management view
-/// - `POST /profile/contact/add` - Add new owner contact
-/// - `GET /profile/contact/list` - Get owner contacts
-/// - `DELETE /profile/contact/delete/{contact_id}` - Delete owner contact
-/// - `DELETE /profile/delete-data` - Delete all user data
-/// - `POST /profile/logout` - Close user session
+/// User profile, contacts, and account operations
 pub fn user_profile(cfg: &mut web::ServiceConfig) {
     cfg.service(web::scope("/profile").service((
         profile::get_profile_view,
@@ -128,40 +63,19 @@ pub fn user_profile(cfg: &mut web::ServiceConfig) {
     )));
 }
 
-/// Configures payment and subscription checkout routes.
-///
-/// This function sets up routes for handling subscription payments and
-/// checkout processes. Routes require user authentication.
-///
-/// # Routes
-/// - `GET /checkout` - Checkout page view
-/// - `POST /checkout/process` - Process payment
+/// Payment and subscription checkout
 pub fn checkout(cfg: &mut web::ServiceConfig) {
     cfg.service(
         web::scope("/checkout").service((checkout::get_checkout_view, checkout::process_payment)),
     );
 }
 
-/// Configures blog and content routes.
-///
-/// This function sets up routes for serving blog content and informational
-/// pages. These routes are typically public and don't require authentication.
-///
-/// # Routes
-/// - `GET /blog/{entry_id}` - View blog entry
+/// Blog content routes
 pub fn blog(cfg: &mut web::ServiceConfig) {
     cfg.service(web::scope("/blog").service((blog::get_blog_entry,)));
 }
 
-/// Configures webhook routes for external integrations.
-///
-/// This function sets up routes for receiving webhook events from external
-/// services like WhatsApp Business API. These routes are public endpoints
-/// that don't require authentication.
-///
-/// # Routes
-/// - `GET /webhook/whatsapp` - WhatsApp webhook verification
-/// - `POST /webhook/whatsapp` - WhatsApp webhook receiver
+/// Webhook handlers for external integrations
 pub fn webhooks(cfg: &mut web::ServiceConfig) {
     cfg.service(
         web::scope("/webhook/whatsapp")

--- a/web_app/src/front/server.rs
+++ b/web_app/src/front/server.rs
@@ -1,5 +1,3 @@
-//! Handlers not linked to a specific url
-
 use ntex::web;
 use ntex_files::NamedFile;
 use ntex_identity::Identity;
@@ -10,18 +8,18 @@ use crate::{
     front::{AppState, errors, middleware, oauth, session, templates, utils},
 };
 
-/// Serve `favicon.ico`
+/// Serve favicon.ico
 #[web::get("/favicon.ico")]
 async fn serve_favicon() -> Result<impl web::Responder, web::Error> {
     Ok(NamedFile::open("web/static/images/favicon.ico")?)
 }
 
-/// Return a [UrlNotFound](errors::UserError::UrlNotFound) error for urls not defined
+/// Handle 404 not found
 pub async fn serve_not_found() -> Result<web::HttpResponse, web::Error> {
     Err(errors::UserError::UrlNotFound.into())
 }
 
-/// Endpoint to render the index view
+/// Render index page
 #[web::get("/")]
 async fn index(cookie: ntex_session::Session) -> Result<impl web::Responder, web::Error> {
     let (auth_url, csrf_state) = oauth::get_new_auth_url();
@@ -53,7 +51,7 @@ async fn index(cookie: ntex_session::Session) -> Result<impl web::Responder, web
         ))
 }
 
-/// Endpoint to render the reactivate account starting point
+/// Render reactivate account page
 #[web::get("/reactivate-account")]
 async fn get_reactivate_account_view(
     _: session::WebAppSession,
@@ -69,8 +67,7 @@ async fn get_reactivate_account_view(
     ))
 }
 
-/// Endpoint handles the request to reactivate an account.
-/// An account is deactivated if the user deleted all the data
+/// Handle account reactivation request
 #[web::post("/reactivate-account")]
 async fn reactivate_account(
     _: middleware::csrf_token::CsrfToken,

--- a/web_app/src/front/templates.rs
+++ b/web_app/src/front/templates.rs
@@ -1,30 +1,19 @@
 use std::sync::LazyLock;
 use tera::Tera;
 
-/// Global Tera template engine instance for web HTML templates.
-///
-/// This lazy-loaded static instance loads all HTML templates from the
-/// `web/templates/` directory and its subdirectories. The templates are
-/// compiled once at first access and cached for subsequent use.
+/// HTML templates from web/templates/
 pub static WEB_TEMPLATES: LazyLock<Tera> =
     LazyLock::new(|| Tera::new("web/templates/**/*.html").unwrap());
 
+/// Webmanifest templates
 pub static WEB_MANIFESTS: LazyLock<Tera> =
     LazyLock::new(|| Tera::new("web/templates/**/*.webmanifest").unwrap());
 
-/// Global Tera template engine instance for PDF report templates.
-///
-/// This lazy-loaded static instance loads all Typst templates from the
-/// `web/reports/` directory. These templates are used for generating
-/// PDF reports using the Typst typesetting system.
+/// Typst templates for PDF reports
 pub static PDF_REPORT_TEMPLATES: LazyLock<Tera> =
     LazyLock::new(|| Tera::new("web/reports/**/*.typ").unwrap());
 
-/// Global Tera template engine instance for blog markdown templates.
-///
-/// This lazy-loaded static instance loads all Markdown templates from the
-/// `web/blog/` directory. These templates are used for rendering blog
-/// content and posts.
+/// Markdown blog templates
 pub static BLOG_TEMPLATES: LazyLock<Tera> = LazyLock::new(|| Tera::new("web/blog/*.md").unwrap());
 
 #[cfg(test)]


### PR DESCRIPTION
- Make all doc comments concise and descriptive
- Remove verbose explanations and examples
- Shorten module-level and function-level docs
- Remove redundant test documentation